### PR TITLE
Updated SCSS styling for "cta-btn--hero" class

### DIFF
--- a/src/style/components/_buttons.scss
+++ b/src/style/components/_buttons.scss
@@ -24,12 +24,24 @@
 /* Hero Style */
 .cta-btn--hero {
   @include supportColorForIE11();
-  border: 2px solid transparent;
+  border-width: 2px;
+  border-style: solid;
+  -moz-border-image: -moz-linear-gradient(
+    135deg,
+    $primary-color 0%,
+    $secondary-color 100%
+  );
+  -webkit-border-image: -webkit-linear-gradient(
+    135deg,
+    $primary-color 0%,
+    $secondary-color 100%
+  );
   border-image: linear-gradient(
     135deg,
     $primary-color 0%,
     $secondary-color 100%
   );
+  -webkit-border-image-slice: 1;
   border-image-slice: 1;
   @include supportIE11() {
     color: $secondary-color !important;


### PR DESCRIPTION
The "hero" buttons' border don't show on the newer Safari versions due to a browser-specific bug. I modified the _buttons.scss file to fix the issue.

Supported browsers for "border-image" CSS proprety:
[https://caniuse.com/border-image](url)