### PR TITLE
changed deprecated links from 'cobidev' to 'cobiwave' due to profile name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Simplefolio ⚡️ [![GitHub](https://img.shields.io/github/license/cobidev/simplefolio?color=blue)](https://github.com/cobidev/simplefolio/blob/master/LICENSE.md) ![GitHub stars](https://img.shields.io/github/stars/cobidev/simplefolio) ![GitHub forks](https://img.shields.io/github/forks/cobidev/simplefolio)
+# Simplefolio ⚡️ [![GitHub](https://img.shields.io/github/license/cobiwave/simplefolio?color=blue)](https://github.com/cobiwave/simplefolio/blob/master/LICENSE.md) ![GitHub stars](https://img.shields.io/github/stars/cobiwave/simplefolio) ![GitHub forks](https://img.shields.io/github/forks/cobiwave/simplefolio)
 
 ## A minimal portfolio template for Developers!
 
 <h2 align="center">
-  <img src="https://github.com/cobidev/gatsby-simplefolio/blob/master/examples/example.gif" alt="Simplefolio" width="600px" />
+  <img src="https://github.com/cobiwave/gatsby-simplefolio/blob/master/examples/example.gif" alt="Simplefolio" width="600px" />
   <br>
 </h2>
 
@@ -55,7 +55,7 @@ From your command line, first clone Simplefolio:
 
 ```bash
 # Clone the repository
-$ git clone https://github.com/cobidev/simplefolio
+$ git clone https://github.com/cobiwave/simplefolio
 
 # Move into the repository
 $ cd simplefolio
@@ -97,7 +97,7 @@ $ sudo npm install --unsafe-perm=true --allow-root
 Once your server has started, go to this url `http://localhost:1234/` to see the portfolio locally. It should look like the below screenshot.
 
 <h2 align="center">
-  <img src="https://github.com/cobidev/gatsby-simplefolio/blob/master/examples/example.png" alt="Simplefolio" width="100%">
+  <img src="https://github.com/cobiwave/gatsby-simplefolio/blob/master/examples/example.png" alt="Simplefolio" width="100%">
 </h2>
 
 ---
@@ -328,7 +328,7 @@ I highly recommend to use [Netlify](https://netlify.com) because it is super eas
 
 ## Others versions 👥
 
-[Gatsby Simplefolio](https://github.com/cobidev/gatsby-simplefolio) by [Jacobo Martinez](https://github.com/cobidev)\
+[Gatsby Simplefolio](https://github.com/cobiwave/gatsby-simplefolio) by [Jacobo Martinez](https://github.com/cobiwave)\
 [Ember.js Simplefolio](https://github.com/sernadesigns/simplefolio-ember) by [Michael Serna](https://github.com/sernadesigns)
 
 ## Technologies used 🛠️
@@ -341,7 +341,7 @@ I highly recommend to use [Netlify](https://netlify.com) because it is super eas
 
 ## Authors
 
-- **Jacobo Martinez** - [https://github.com/cobidev](https://github.com/cobidev)
+- **Jacobo Martinez** - [https://github.com/cobiwave](https://github.com/cobiwave)
 
 ## Status
 

--- a/src/index.html
+++ b/src/index.html
@@ -4,8 +4,8 @@
   Simplefolio is a clean and responsive portfolio template for Developers!
   Created by Jacobo Martinez.
   -
-  Github Repo: https://github.com/cobidev/simplefolio/
-  Readme: https://github.com/cobidev/simplefolio/README.md
+  Github Repo: https://github.com/cobiwave/simplefolio/
+  Readme: https://github.com/cobiwave/simplefolio/README.md
   -
   For business & inquires, contact me -> jacobojavier98@gmail.com
 -->
@@ -315,7 +315,7 @@
         <!-- Notice: if you want to give me some credit, it will be huge for me! if not, put your data on it -->
         <p class="footer__text">
           © 2021 - Template developed by
-          <a rel="noreferrer" href="https://github.com/cobidev" target="_blank"
+          <a rel="noreferrer" href="https://github.com/cobiwave" target="_blank"
             >Jacobo Martínez</a
           >
         </p>
@@ -325,7 +325,7 @@
           <a
             rel="noreferrer"
             class="github-button"
-            href="https://github.com/cobidev/simplefolio/fork"
+            href="https://github.com/cobiwave/simplefolio/fork"
             data-icon="octicon-repo-forked"
             data-size="large"
             data-show-count="true"
@@ -335,11 +335,11 @@
           <a
             rel="noreferrer"
             class="github-button"
-            href="https://github.com/cobidev/simplefolio"
+            href="https://github.com/cobiwave/simplefolio"
             data-icon="octicon-star"
             data-size="large"
             data-show-count="true"
-            aria-label="Star cobidev/simplefolio on GitHub"
+            aria-label="Star cobiwave/simplefolio on GitHub"
             >Star</a
           >
         </p>


### PR DESCRIPTION
Original contributor changed its profile name from `cobidev` to `cobiwave`. This leads to a couple of deprecated links in the project &rightarrow; clicking them lead to `404 errors`. All occurences of the deprecated profile name are changed to the new one during this contribution